### PR TITLE
Add create entity task, bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cypress-wikibase-api",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cypress-wikibase-api",
-			"version": "0.0.1",
+			"version": "0.0.2",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"api-testing": "^1.7.0"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"api-testing": "^1.7.0"
 	},
 	"name": "cypress-wikibase-api",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"description": "Support package for developing cypress tests that use the Wikibase API",
 	"homepage": "https://github.com/wmde/cypress-wikibase-api",
 	"bugs": "https://phabricator.wikimedia.org",

--- a/src/MwApiPlugin.js
+++ b/src/MwApiPlugin.js
@@ -82,6 +82,35 @@ module.exports = {
 			return token;
 		}
 
+		async function createEntity( entityType, label, data ) {
+			const itemData = {};
+			let labels = {};
+
+			if ( typeof label === 'object' ) {
+				labels = label;
+			} else if ( label ) {
+				labels = {
+					en: {
+						language: 'en',
+						value: label
+					}
+				};
+			}
+
+			Object.assign( itemData, { labels }, data );
+
+			const bot = await botUser();
+			const botToken = await getBotEditToken( bot );
+
+			const response = await bot.request( {
+				action: 'wbeditentity',
+				new: entityType,
+				data: JSON.stringify( itemData ),
+				token: botToken
+			}, true );
+			return response.body.entity.id;
+		}
+
 		return {
 			async 'MwApi:BlockUser'( { username, reason, expiry } ) {
 				const rootClient = await root();
@@ -108,32 +137,10 @@ module.exports = {
 				return Promise.resolve( { username, password } );
 			},
 			async 'MwApi:CreateItem'( { label, data } ) {
-				const itemData = {};
-				let labels = {};
-
-				if ( typeof label === 'object' ) {
-					labels = label;
-				} else if ( label ) {
-					labels = {
-						en: {
-							language: 'en',
-							value: label
-						}
-					};
-				}
-
-				Object.assign( itemData, { labels }, data );
-
-				const bot = await botUser();
-				const botToken = await getBotEditToken( bot );
-
-				const response = await bot.request( {
-					action: 'wbeditentity',
-					new: 'item',
-					data: JSON.stringify( itemData ),
-					token: botToken
-				}, true );
-				return response.body.entity.id;
+				return createEntity( 'item', label, data );
+			},
+			async 'MwApi:CreateEntity'( { entityType, label, data } ) {
+				return createEntity( entityType, label, data );
 			},
 			async 'MwApi:GetEntityData'( { entityId } ) {
 				const bot = await botUser();


### PR DESCRIPTION
Add `MwApi:CreateEntity` cypress task to allow creation of non-item
entities (e.g. Lexemes).
Bump version to 0.0.2