### PR TITLE
Update the location of the .npmrc file in npm publish step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
         run: npm test
       - name: Publish
         run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}" > ~/.npmrc
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}" > ${NPM_CONFIG_USERCONFIG}
           npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
The location of the .npmrc file seems not to be ~/.npmrc in the new github npm publish action. Update the location in our action script so that the auth token is available.