### PR TITLE
Get or create a property with a datatype, bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cypress-wikibase-api",
-	"version": "0.0.5",
+	"version": "0.0.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cypress-wikibase-api",
-			"version": "0.0.5",
+			"version": "0.0.6",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"api-testing": "^1.7.0"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"api-testing": "^1.7.0"
 	},
 	"name": "cypress-wikibase-api",
-	"version": "0.0.5",
+	"version": "0.0.6",
 	"description": "Support package for developing cypress tests that use the Wikibase API",
 	"homepage": "https://github.com/wmde/cypress-wikibase-api",
 	"bugs": "https://phabricator.wikimedia.org",

--- a/src/MwApiPlugin.js
+++ b/src/MwApiPlugin.js
@@ -174,10 +174,17 @@ module.exports = {
 				return createProperty( datatype, label, data );
 			},
 			async 'MwApi:GetOrCreatePropertyIdByDataType'( { datatype } ) {
-				if ( cypressConfig.wikibasePropertyIds && cypressConfig.wikibasePropertyIds[ datatype ] ) {
+				if ( !( 'wikibasePropertyIds' in cypressConfig ) ) {
+					cypressConfig.wikibasePropertyIds = {};
+				}
+				if ( cypressConfig.wikibasePropertyIds[ datatype ] ) {
 					return Promise.resolve( cypressConfig.wikibasePropertyIds[ datatype ] );
 				} else {
-					return createProperty( datatype, utils.title( datatype ) );
+					return createProperty( datatype, utils.title( datatype ) )
+						.then( ( propertyId ) => {
+							cypressConfig.wikibasePropertyIds[ datatype ] = propertyId;
+							return propertyId;
+						} );
 				}
 			},
 			async 'MwApi:GetEntityData'( { entityId } ) {


### PR DESCRIPTION
Add `MwApi:CreateProperty`, which creates a property as the root user.
Add `MwApi:GetOrCreatePropertyIdByDataType`, which allows reuse of properties via setting a config variable, or if it isn't set, creates the property

bump version to `0.0.6`