### PR TITLE
Add functions for forms and sense

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cypress-wikibase-api",
-	"version": "0.0.6",
+	"version": "0.0.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cypress-wikibase-api",
-			"version": "0.0.6",
+			"version": "0.0.7",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"api-testing": "^1.7.0"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"api-testing": "^1.7.0"
 	},
 	"name": "cypress-wikibase-api",
-	"version": "0.0.6",
+	"version": "0.0.7",
 	"description": "Support package for developing cypress tests that use the Wikibase API",
 	"homepage": "https://github.com/wmde/cypress-wikibase-api",
 	"bugs": "https://phabricator.wikimedia.org",

--- a/src/MwApiPlugin.js
+++ b/src/MwApiPlugin.js
@@ -139,6 +139,26 @@ module.exports = {
 			return response.entity.id;
 		}
 
+		async function addSense( lexemeId, data ) {
+			const rootClient = await root();
+			const response = await rootClient.action( 'wbladdsense', {
+				lexemeId,
+				data: JSON.stringify( data ),
+				token: await rootClient.token()
+			}, 'POST' );
+			return response.sense.id;
+		}
+
+		async function addForm( lexemeId, data ) {
+			const rootClient = await root();
+			const response = await rootClient.action( 'wbladdform', {
+				lexemeId,
+				data: JSON.stringify( data ),
+				token: await rootClient.token()
+			}, 'POST' );
+			return response.form.id;
+		}
+
 		return {
 			async 'MwApi:BlockUser'( { username, reason, expiry } ) {
 				const rootClient = await root();
@@ -172,6 +192,12 @@ module.exports = {
 			},
 			async 'MwApi:CreateProperty'( { datatype, label, data } ) {
 				return createProperty( datatype, label, data );
+			},
+			async 'MwApi:AddSense'( { lexemeId, data } ) {
+				return addSense( lexemeId, data );
+			},
+			async 'MwApi:AddForm'( { lexemeId, data } ) {
+				return addForm( lexemeId, data );
 			},
 			async 'MwApi:GetOrCreatePropertyIdByDataType'( { datatype } ) {
 				if ( !( 'wikibasePropertyIds' in cypressConfig ) ) {


### PR DESCRIPTION
For the wbui2025 / MEX development we need to be able to create forms and senses from cypress.

Add `MwApi:AddSense` and `MwApi:AddForm` functions so that we can test sense and form functionality.

Bug: T403974