### PR TITLE
Fix `.action()` usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cypress-wikibase-api",
-	"version": "0.0.8",
+	"version": "0.0.9",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cypress-wikibase-api",
-			"version": "0.0.8",
+			"version": "0.0.9",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"api-testing": "^1.7.0"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"api-testing": "^1.7.0"
 	},
 	"name": "cypress-wikibase-api",
-	"version": "0.0.8",
+	"version": "0.0.9",
 	"description": "Support package for developing cypress tests that use the Wikibase API",
 	"homepage": "https://github.com/wmde/cypress-wikibase-api",
 	"bugs": "https://phabricator.wikimedia.org",

--- a/src/MwApiPlugin.js
+++ b/src/MwApiPlugin.js
@@ -82,7 +82,7 @@ module.exports = {
 				data: JSON.stringify( itemData ),
 				token: await bot.token()
 			}, true );
-			return response.body.entity.id;
+			return response.entity.id;
 		}
 
 		async function createProperty( datatype, label, data ) {
@@ -190,7 +190,7 @@ module.exports = {
 
 				return bot.action( 'wbgetentities', {
 					ids: entityId
-				} ).then( ( response ) => response.body.entities[ entityId ] );
+				} ).then( ( response ) => response.entities[ entityId ] );
 			},
 			async 'MwApi:UnblockUser'( { username, reason } ) {
 				const rootClient = await root();
@@ -215,7 +215,7 @@ module.exports = {
 				if ( isEdit ) {
 					requestParams.token = await bot.token();
 				}
-				return bot.action( action, requestParams, isPost ).then( ( response ) => response.body );
+				return bot.action( action, requestParams, isPost );
 			}
 		};
 	}


### PR DESCRIPTION
That method returns the body directly, not the full response, my bad.

----

Let’s test this in Wikibase CI before merging it, I’ll try to update [this change](https://gerrit.wikimedia.org/r/c/mediawiki/extensions/Wikibase/+/1226790) accordingly.