### PR TITLE
Introduce MwApi:DeletePage as command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cypress-wikibase-api",
-	"version": "0.0.9",
+	"version": "0.0.10",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cypress-wikibase-api",
-			"version": "0.0.9",
+			"version": "0.0.10",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"api-testing": "^1.7.0"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"api-testing": "^1.7.0"
 	},
 	"name": "cypress-wikibase-api",
-	"version": "0.0.9",
+	"version": "0.0.10",
 	"description": "Support package for developing cypress tests that use the Wikibase API",
 	"homepage": "https://github.com/wmde/cypress-wikibase-api",
 	"bugs": "https://phabricator.wikimedia.org",

--- a/src/MwApiPlugin.js
+++ b/src/MwApiPlugin.js
@@ -131,6 +131,16 @@ module.exports = {
 			return response.form.id;
 		}
 
+		async function deletePage( title ) {
+			const rootClient = await root();
+			await rootClient.action( 'delete', {
+				title,
+				reason: 'Cypress MwApi Deletion',
+				token: await rootClient.token(),
+			}, 'POST' );
+			return null;
+		}
+
 		return {
 			async 'MwApi:BlockUser'( { username, reason, expiry } ) {
 				const rootClient = await root();
@@ -191,6 +201,9 @@ module.exports = {
 				return bot.action( 'wbgetentities', {
 					ids: entityId
 				} ).then( ( response ) => response.entities[ entityId ] );
+			},
+			async 'MwApi:DeletePage'( { title } ) {
+				return deletePage( title );
 			},
 			async 'MwApi:UnblockUser'( { username, reason } ) {
 				const rootClient = await root();


### PR DESCRIPTION
Wikibase includes a test for wbui2025 that deletes a wiki page in order to test feature interactions with deleted items.

Extend the MwApi library to include the DeletePage functionality so that other extensions can use the same functionality.

Bug: T427277