### PR TITLE
Update github actions to test on PR / merge, fix publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           registry-url: https://registry.npmjs.org/
       - name: Install
         run: npm ci
@@ -20,6 +20,6 @@ jobs:
       - name: Publish
         run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}" > ${NPM_CONFIG_USERCONFIG}
-          npm publish --access public
+          npm stage publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Test on code push
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org/
+      - name: Install
+        run: npm ci
+      - name: Test
+        run: npm test


### PR DESCRIPTION
The current publish action in this repository fails because of NPM's 2-factor authentication / staged release process. In addition, there is currently no testing of pull requests or pushes to main, meaning that we only find out if code passes tests when the release action is being triggered.

Introduce new actions for pull request and pushes to main, and fix the publish action to use NPM's staging support.

Bug: T428719